### PR TITLE
Fix error xdebug log file missing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
             - ./config.env
         volumes:
             - ./logs/php:/var/log/php
-            - ./logs/php/xdebug/:/var/log/php
+            - ./logs/php/xdebug/:/var/log/php/xdebug
             - ./config/magento/php.ini.sample:/usr/local/etc/php/php.ini
             - ./config/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
             - ./config/php/conf.d/php.ini:/usr/local/etc/php/conf.d/docker-php-ext-error.ini


### PR DESCRIPTION
Fix error xdebug log file missing

XDebug could not open the remote debug file '/var/log/php/xdebug-remote.log'